### PR TITLE
update to use Qt6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@
 #
 from . import rtkkw
 from anki.hooks import addHook
-from PyQt5.QtWidgets import QAction
+from PyQt6.QtGui import QAction
 
 def start(browser):
     from importlib import reload

--- a/rtkkw.py
+++ b/rtkkw.py
@@ -1,7 +1,7 @@
 ﻿
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QAction
+from PyQt6.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtGui import QAction
 
 from aqt import mw
 from anki.decks import DeckManager


### PR DESCRIPTION
Anki no longer provides Qt5 build releases starting from release version 25.02, so I've made the changes according to #4. 